### PR TITLE
fix(CD): actions/cacheのrestore実行タイミングを修正

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -19,21 +19,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - run: yarn install --prefer-offline
-
-      - run: yarn build
-
       - name: cache node_modules
         id: node_modules_cache_id
         uses: actions/cache@v2
         with:
-          path:
-            node_modules
+          path: node_modules
           key: node-v${{ matrix.node-version }}-deps-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - if: steps.node_modules_cache_id.outputs.cache-hit != 'true'
+        run: yarn install
+
+      - run: yarn build
 
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/firebase-hosting-pr.yml
+++ b/.github/workflows/firebase-hosting-pr.yml
@@ -19,21 +19,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - run: yarn install --prefer-offline
-
-      - run: yarn build
-
       - name: cache node_modules
         id: node_modules_cache_id
         uses: actions/cache@v2
         with:
-          path:
-            node_modules
+          path: node_modules
           key: node-v${{ matrix.node-version }}-deps-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - if: steps.node_modules_cache_id.outputs.cache-hit != 'true'
+        run: yarn install
+
+      - run: yarn build
 
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
`yarn install`してからCacheのリストアを行うという無駄な動作を行っていたため, cacheのリストアを試行してから, リストアに失敗した場合のみ`yarn install`を実行するように修正を行った